### PR TITLE
Bugfix: Get-LocalPolicySystemSettings currently returns user policies

### DIFF
--- a/LGPO/LGPO.psm1
+++ b/LGPO/LGPO.psm1
@@ -84,7 +84,7 @@ Function Get-LocalPolicySettings {
             #Build argumentlist
             $lgpoargs = @()
             $lgpoargs += '/parse'
-            If($Policy -eq 'Computer'){
+            If($Policy -in @('Computer', 'Machine')){
                 $lgpoargs += '/m'
                 $PolicyPath = 'Machine'
             }Else{


### PR DESCRIPTION
The `Get-LocalPolicySystemSettings` function specifies "Machine" as the value for the **Policy** property in the parameter splat for the call to `Get-LocalPolicySettings`. This value is accepted by the parameter validation, but the IF statement that constructs the arguments passed to LGPO.exe only matches on "Computer".